### PR TITLE
Testing modal component

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -94,7 +94,9 @@
               "./node_modules/bootstrap-icons/font/bootstrap-icons.css",
               "src/styles.css"
             ],
+						"codeCoverage": true,
             "scripts": []
+
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "rest-server": "json-server --watch src/data/coffee-data.json --port 8100",
-    "test": "ng test"
+    "test": "ng test --no-watch --no-progress --browsers=ChromeHeadless"
   },
   "private": true,
   "dependencies": {

--- a/src/app/modal/modal.component.spec.ts
+++ b/src/app/modal/modal.component.spec.ts
@@ -1,23 +1,42 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ModalComponent } from './modal.component';
+import { ModalService } from './modal.service';
+import { ElementRef } from '@angular/core';
 
-xdescribe('ModalComponent', () => {
-  let component: ModalComponent;
-  let fixture: ComponentFixture<ModalComponent>;
+describe('ModalComponent', () => {
+	let component: ModalComponent;
+	let fixture: ComponentFixture<ModalComponent>;
+	let modalService: jasmine.SpyObj<ModalService>;
+	let elementRef: ElementRef;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ModalComponent]
-    })
-    .compileComponents();
+	beforeEach(async () => {
+		const modalService = jasmine.createSpyObj('ModalService', ['add', 'remove']);
+		elementRef = new ElementRef(document.getElementById('div'));
 
-    fixture = TestBed.createComponent(ModalComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+		await TestBed.configureTestingModule({
+			imports: [ModalComponent],
+			providers: [
+				{ provide: ModalService, useValue: modalService },
+				{ provide: ElementRef, useValue: elementRef },
+			],
+		}).compileComponents();
+	});
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+	beforeEach(() => {
+		fixture = TestBed.createComponent(ModalComponent);
+		component = fixture.componentInstance;
+		modalService = TestBed.inject(ModalService) as jasmine.SpyObj<ModalService>;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+
+	it('should add on init', () => {
+		spyOn(document.body, 'appendChild').and.callThrough();
+		component.ngOnInit();
+		expect(document.body.appendChild).toHaveBeenCalledWith(component['element']);
+	});
 });

--- a/src/app/modal/modal.component.spec.ts
+++ b/src/app/modal/modal.component.spec.ts
@@ -39,4 +39,31 @@ describe('ModalComponent', () => {
 		component.ngOnInit();
 		expect(document.body.appendChild).toHaveBeenCalledWith(component['element']);
 	});
+
+	it('should open the modal', () => {
+		component.open();
+		expect(component['element'].style.display).toBe('block');
+		expect(document.body.classList.contains('modal-open')).toBeTrue();
+		expect(component.isOpen).toBeTrue();
+	});
+
+	it('should close the modal', () => {
+		component.close();
+		expect(component['element'].style.display).toBe('none');
+		expect(document.body.classList.contains('modal-open')).toBeFalse();
+		expect(component.isOpen).toBeFalse();
+	});
+
+	it('should set up click listener for background click to close', () => {
+		spyOn(component, 'close');
+		component.ngOnInit();
+
+		const event = new MouseEvent('click', { bubbles: true });
+		const targetElement = document.createElement('div');
+		targetElement.className = 'modal';
+		Object.defineProperty(event, 'target', { value: targetElement, writable: false });
+
+		component['element'].dispatchEvent(event);
+		expect(component.close).toHaveBeenCalled();
+	});
 });

--- a/src/app/service/http.service.spec.ts
+++ b/src/app/service/http.service.spec.ts
@@ -7,6 +7,7 @@ import {
 	mockCoffeeArray,
 	mockCoffeeArrayByRoaster,
 } from '../mocks/mockCoffee';
+import { CoffeeModel, RoastType, SizeType } from '../model/CoffeeModel';
 
 describe('HttpService', () => {
 	let service: HttpService;
@@ -26,7 +27,7 @@ describe('HttpService', () => {
 		httpController.verify();
 	});
 
-	it('should be created', () => {
+	it('should create', () => {
 		expect(service).toBeTruthy();
 	});
 
@@ -85,5 +86,32 @@ describe('HttpService', () => {
 		});
 
 		req.flush(mockCoffeeArrayByRoaster);
+	});
+
+	it('should call putCoffee and return the updated coffee from the API', () => {
+		const updatedCoffee: CoffeeModel = {
+			id: 1,
+			active: false,
+			roaster: "Tim Horton's",
+			variety: '',
+			size: 14,
+			roast: RoastType.DARK,
+			format: 'k-pod',
+			grind: SizeType.TWENTYFOUR,
+			origin: [''],
+			singleOrigin: true,
+			tastingNotes: '',
+		};
+
+		service.putCoffee(mockCoffee1).subscribe((data) => {
+			expect(data).toEqual(updatedCoffee);
+		});
+
+		const req = httpController.expectOne({
+			method: 'PUT',
+			url: `${baseUrl}/coffees/${updatedCoffee.id}`,
+		});
+
+		req.flush(updatedCoffee);
 	});
 });

--- a/src/app/service/http.service.ts
+++ b/src/app/service/http.service.ts
@@ -23,9 +23,9 @@ export class HttpService {
 		return this.client.post<CoffeeModel>(`${this.baseUrl}/coffees`, formData);
 	}
 
-	putCoffee(formData: CoffeeModel): Observable<CoffeeModel[]> {
+	putCoffee(formData: CoffeeModel): Observable<CoffeeModel> {
 		const id = formData.id;
-		return this.client.put<CoffeeModel[]>(`${this.baseUrl}/coffees/${id}`, formData);
+		return this.client.put<CoffeeModel>(`${this.baseUrl}/coffees/${id}`, formData);
 	}
 
 	getCoffeeByField(field: string, value: string): Observable<CoffeeModel[]> {

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -1,0 +1,21 @@
+module.exports = function (config) {
+	config.set({
+		coverageReporter: {
+			dir: require('path').join(__dirname, 'coverage'),
+			subdir: '.',
+			reporters: [
+				{ type: 'html', dir:'coverage/' },
+				{ type: 'lcov' },
+				{ type: 'text-summary' }
+			],
+			check: {
+				global: {
+					statements: 80,
+					branches: 80,
+					functions: 80,
+					lines: 80
+				}
+			}
+		},
+	});
+};


### PR DESCRIPTION
Added addtional tests for the modal component. Added karma.config.js where we can now run test headless which will also generate a coverage report. To run the updated tests suites use:

`npm test`

